### PR TITLE
fix: silence node12 deprecation warnings

### DIFF
--- a/sync/action.yaml
+++ b/sync/action.yaml
@@ -27,7 +27,7 @@ runs:
       run: git diff
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       id: cpr
       with:
         token: ${{ inputs.github-personal-access-token }}


### PR DESCRIPTION
Upgrade to v4 of peter-evans/create-pull-request action to silence GitHub warnings about Node.js 12 actions being deprecated. V4 uses Node.js v16.