### PR TITLE
fix: project name cannot contain slash

### DIFF
--- a/run-sync/action.yaml
+++ b/run-sync/action.yaml
@@ -76,28 +76,28 @@ runs:
     - name: start 1password connect
       shell: bash
       env:
-        COMPOSE_PROJECT_NAME: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
+        COMPOSE_PROJECT_NAME: ${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
       working-directory: ${{ runner.temp }}/kubesealer
       run: docker-compose up -d op-connect-api op-connect-sync
 
     - name: logs
       shell: bash
       env:
-        COMPOSE_PROJECT_NAME: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
+        COMPOSE_PROJECT_NAME: ${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
       working-directory: ${{ runner.temp }}/kubesealer
       run: docker-compose logs
 
     - name: kubesealer sync
       shell: bash
       env:
-        COMPOSE_PROJECT_NAME: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
+        COMPOSE_PROJECT_NAME: ${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
       run: docker-compose -f ${RUNNER_TEMP}/kubesealer/docker-compose.yaml run --rm -v "$(pwd):/src" kubesealer turo-kubesealer sync --recursive --certs /certs /src
 
     - name: cleanup kubesealer
       if: always()
       shell: bash
       env:
-        COMPOSE_PROJECT_NAME: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
+        COMPOSE_PROJECT_NAME: ${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
       working-directory: ${{ runner.temp }}/kubesealer
       run: |
         echo "List running docker containers"


### PR DESCRIPTION
after update in gha runner to docker compose v2, some runs are failing with error like 
`project name must follow invalid project name "turo/dunlop-deployments-7451808450-1": must consist only of lowercase alphanumeric characters, hyphens, and underscores as well as start with a letter or number`

compose project name should not contain `/`, this PR instead extracts the repo name from github.repository variable (uses last path in turo/...) and uses that to build project name