### PR TITLE
ci: use renovatebot reusable workflows

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,10 +1,6 @@
 name: Update dependencies
-concurrency: update-dependencies
 
 on:
-  schedule:
-    # Every day at midnight
-    - cron: "0 0 * * *"
   workflow_dispatch:
   issue_comment:
     types:
@@ -12,17 +8,9 @@ on:
   pull_request:
     types:
       - edited
+      - synchronize
 
 jobs:
   update-dependencies:
-    runs-on: ubuntu-latest
-    name: Update dependencies
-    # Only run in turo-dependency-manager PRs or when manually triggered or as part of a schedule
-    if: (github.event_name == 'issue_comment' && github.event.issue.user.login == 'turo-dependency-manager') || (github.event_name == 'pull_request' && github.actor == 'turo-dependency-manager') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    steps:
-      - name: Update dependencies
-        uses: open-turo/action-renovate@v1
-        with:
-          github-token: ${{ secrets.TURO_GITHUB_DEPENDENCY_MANAGER_TOKEN }}
-          docker-username: ${{ secrets.DOCKER_USERNAME }}
-          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+    uses: turo/dependency-management-tools/.github/workflows/reusable-workflow.update-dependencies.yaml@v1
+    secrets: inherit


### PR DESCRIPTION

**Description**

This PR updates the renovatebot actions in this repo to use the new reusable workflows we just created in https://github.com/turo/dependency-management-tools



**Changes**

* ci: use renovatebot reusable workflows

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)