### PR TITLE
DEVX-100: Enable to build arm64 kubesealer image

### DIFF
--- a/run-sync/docker-compose.yaml
+++ b/run-sync/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - "./1password-credentials.json:/home/opuser/.op/1password-credentials.json"
       - "data:/home/opuser/.op/data"
   kubesealer:
-    image: turo/kubesealer:4.16.0
+    image: turo/kubesealer:4.17.0
     env_file: .env
 
 volumes:


### PR DESCRIPTION
**Description**
Enable to build arm64 kubesealer image

The prerelase version has been tested in this [run](https://github.com/turo/k8s-cluster-services-deployments/actions/runs/15420103568/job/43392624737).


Fixes [#DEVX-100](https://team-turo.atlassian.net//browse/DEVX-100)

**Changes**

* feat(dockerimage): update docker image to enable arm64

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
