### PR TITLE
Update Support Channel Name

### DIFF
--- a/check/action.yaml
+++ b/check/action.yaml
@@ -74,7 +74,7 @@ runs:
           ```
           @kubesealer run
           ```
-          If you have issues, please each out in [#devops](https://team-turo.slack.com/archives/C1ZP61K7S)
+          If you have issues, please each out in [#platform-support](https://team-turo.slack.com/archives/C1ZP61K7S)
 
     - name: Delete instructions comment
       if: (steps.changes.outputs.secret-templates != 'true' || success()) && steps.fc.outputs.comment-id != ''


### PR DESCRIPTION
## background

`#devops` has been renamed to `#platform-support`.
This PR just makes a small change to the name for less confusion.

## changes
- Rename channel for getting support
